### PR TITLE
Material Design colour tweaks

### DIFF
--- a/paper-dropdown-menu.html
+++ b/paper-dropdown-menu.html
@@ -90,12 +90,12 @@ contains the selection state.
       cursor: pointer;
       padding: 0.5em 0 0.25em;
       margin: 0.75em 0;
-      border-bottom: 1px solid #757575;
+      border-bottom: 1px solid rgba(0, 0, 0, 0.12);
       outline: none;
     }
 
-    #label:not(.selectedItem), #arrow {
-      color: #757575;
+    #label:not(.selectedItem), :host([disabled]) #label, #arrow {
+      color: rgba(0, 0, 0, 0.26);
     }
 
     #label {


### PR DESCRIPTION
Use the colours given in the Material Design spec for the underline effect, label and arrow. Also distinguish a disabled control from an enabled control which has a selection, using the label colour.
